### PR TITLE
feat: improve metadata collection of IndexedDB

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,33 @@
+import sys
+import pathlib
+import ccl_chromium_indexeddb
+import time
+
+def main(args):
+    start = time.time()
+    ldb_path = pathlib.Path(args[0])
+    wrapper = ccl_chromium_indexeddb.WrappedIndexDB(ldb_path)
+
+    for db_info in wrapper.database_ids:
+        db = wrapper[db_info.dbid_no]
+        print("------Database------")
+        print(f"db_number={db.db_number}; name={db.name}; origin={db.origin}")
+        print()
+        print("\t---Object Stores---")
+        for obj_store_name in db.object_store_names:
+            obj_store = db[obj_store_name]
+            print(f"\tobject_store_id={obj_store.object_store_id}; name={obj_store.name}")
+            try:
+                one_record = next(obj_store.iterate_records())
+            except StopIteration:
+                one_record = None
+        print()
+    end = time.time()
+    print("Elapsed time: {} seconds.".format(int(end-start)))
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(f"USAGE: {pathlib.Path(sys.argv[0]).name} <ldb dir path>")
+        exit(1)
+
+    main(sys.argv[1:])


### PR DESCRIPTION
Hi Alex,

Thanks again for your amazing work and for making this library available as an open-source product.

As part of my work on a [forensic parser for Microsoft Teams](https://github.com/lxndrblz/forensicsim/), I have noticed that the way the metadata is fetched for the IndexedDB could be improved. The fact that `iterate_records_raw()` is called three times, even though the database did not change in the meantime, makes it quite slow. By unifying the collection of the metadata, I was able to significantly reduce the time needed to loop through a large database.

# Benchmark
As a benchmark I was looping over the following IndexedDB (contains several object stores and records) using the included benchmark.py script.

https://github.com/lxndrblz/forensicsim/tree/main/testdata/John%20Doe/IndexedDB/https_teams.microsoft.com_0.indexeddb.leveldb

I got 432 seconds before the optimisation and 265 seconds after my optimisation.

Let me know what you think.

Alex
