### PR TITLE
Feat: improve speed of metadata collection by caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /__pycache__
 /__ignore__
 /.idea
+env/

--- a/ccl_chromium_indexeddb.py
+++ b/ccl_chromium_indexeddb.py
@@ -573,7 +573,7 @@ class IndexedDb:
         # goodness me this is a slow way of doing things
         prefix = IndexedDb.make_prefix(db_id, store_id, 1)
 
-        for record in self._db.iterate_records_raw():
+        for record in self._fetched_records():
             if record.key.startswith(prefix):
                 key = IdbKey(record.key[len(prefix):])
                 if not record.value:
@@ -615,7 +615,7 @@ class IndexedDb:
         # TODO: we should at least cache along the way to our record
         # prefix = bytes([0, db_id, store_id, 3])
         prefix = IndexedDb.make_prefix(db_id, store_id, 3)
-        for record in self._db.iterate_records_raw():
+        for record in self._fetched_records:
             if record.user_key.startswith(prefix):
                 this_raw_key = record.user_key[len(prefix):]
                 buff = io.BytesIO(record.value)
@@ -659,7 +659,7 @@ class IndexedDb:
 
         # This is a slow way of doing this:
         prefix = bytes.fromhex("00 00 00 00 32")
-        for record in self._db.iterate_records_raw():
+        for record in self._fetched_records():
             if record.state != ccl_leveldb.KeyState.Live:
                 continue
             if record.user_key.startswith(prefix):

--- a/ccl_chromium_indexeddb.py
+++ b/ccl_chromium_indexeddb.py
@@ -240,7 +240,6 @@ class GlobalMetadata:
                 db_name_length = read_le_varint(buff)
                 db_name = buff.read(db_name_length * 2).decode("utf-16-be")
 
-            # db_id_no = le_varint_from_bytes(dbid_rec.value)
             db_id_no = decode_truncated_int(dbid_rec.value)
 
             dbids.append(DatabaseId(db_id_no, origin, db_name))

--- a/ccl_chromium_indexeddb.py
+++ b/ccl_chromium_indexeddb.py
@@ -350,67 +350,26 @@ class IndexedDb:
         self.global_metadata = None
         self.database_metadata = None
         self.object_store_meta = None
+        self._cache_records()
         self._fetch_meta_data()
-
         self._blob_lookup_cache = {}
 
-    def _fetch_meta_data(self):
-        global_metadata_raw = {}
-
-        database_metadata_raw = {}
-        objectstore_metadata_raw = {}
-
+    def _cache_records(self):
         self._fetched_records = []
         # Fetch the records only once
         for record in self._db.iterate_records_raw():
             self._fetched_records.append(record)
 
-        for record in self._fetched_records:
-            # Global Metadata
-            if record.key.startswith(b"\x00\x00\x00\x00") and record.state == ccl_leveldb.KeyState.Live:
-                if record.key not in global_metadata_raw or global_metadata_raw[record.key].seq < record.seq:
-                    global_metadata_raw[record.key] = record
-
-        # Convert the raw metadata to a nice GlobalMetadata Object
-        global_metadata = GlobalMetadata(global_metadata_raw)
-
-        # Loop through the database IDs
-        for db_id in global_metadata.db_ids:
-            # if db_id.dbid_no > 0x7f:
-            #     raise NotImplementedError("there could be this many dbs, but I don't support it yet")
-            #
-            # # Database keys end with 0
-            # prefix_database = bytes([0, db_id.dbid_no, 0, 0])
-            #
-            # # Objetstore keys end with 50
-            # prefix_objectstore = bytes([0, db_id.dbid_no, 0, 0, 50])
-
-            prefix_database = IndexedDb.make_prefix(db_id.dbid_no, 0, 0)
-            prefix_objectstore = IndexedDb.make_prefix(db_id.dbid_no, 0, 0, [50])
-
-            for record in reversed(self._fetched_records):
-                if record.key.startswith(prefix_database) and record.state == ccl_leveldb.KeyState.Live:
-                    # we only want live keys and the newest version thereof (highest seq)
-                    meta_type = record.key[len(prefix_database)]
-                    old_version = database_metadata_raw.get((db_id.dbid_no, meta_type))
-                    if old_version is None or old_version.seq < record.seq:
-                        database_metadata_raw[(db_id.dbid_no, meta_type)] = record
-                if record.key.startswith(prefix_objectstore) and record.state == ccl_leveldb.KeyState.Live:
-                    # we only want live keys and the newest version thereof (highest seq)
-                    try:
-                        objstore_id, varint_raw = _le_varint_from_bytes(record.key[len(prefix_objectstore):])
-                    except TypeError:
-                        continue
-
-                    meta_type = record.key[len(prefix_objectstore) + len(varint_raw)]
-
-                    old_version = objectstore_metadata_raw.get((db_id.dbid_no, objstore_id, meta_type))
-
-                    if old_version is None or old_version.seq < record.seq:
-                        objectstore_metadata_raw[(db_id.dbid_no, objstore_id, meta_type)] = record
-
-        self.global_metadata = global_metadata
+    def _fetch_meta_data(self):
+        global_metadata_raw = {}
+        database_metadata_raw = {}
+        objectstore_metadata_raw = {}
+        # Fetch metadata
+        global_metadata_raw = self._get_raw_global_metadata()
+        self.global_metadata = GlobalMetadata(global_metadata_raw)
+        database_metadata_raw = self._get_raw_database_metadata()
         self.database_metadata = DatabaseMetadata(database_metadata_raw)
+        objectstore_metadata_raw = self._get_raw_object_store_metadata()
         self.object_store_meta = ObjectStoreMetadata(objectstore_metadata_raw)
 
     @staticmethod
@@ -488,7 +447,7 @@ class IndexedDb:
         if not live_only:
             raise NotImplementedError("Deleted metadata not implemented yet")
         meta = {}
-        for record in self._db.iterate_records_raw(reverse=True):
+        for record in reversed(self._fetched_records):
             if record.key.startswith(b"\x00\x00\x00\x00") and record.state == ccl_leveldb.KeyState.Live:
                 # we only want live keys and the newest version thereof (highest seq)
                 if record.key not in meta or meta[record.key].seq < record.seq:
@@ -503,12 +462,13 @@ class IndexedDb:
         db_meta = {}
 
         for db_id in self.global_metadata.db_ids:
-            # if db_id.dbid_no > 0x7f:
-            #     raise NotImplementedError("there could be this many dbs, but I don't support it yet")
+
+            if db_id.dbid_no is None:
+                continue
 
             # prefix = bytes([0, db_id.dbid_no, 0, 0])
             prefix = IndexedDb.make_prefix(db_id.dbid_no, 0, 0)
-            for record in self._db.iterate_records_raw(reverse=True):
+            for record in reversed(self._fetched_records):
                 if record.key.startswith(prefix) and record.state == ccl_leveldb.KeyState.Live:
                     # we only want live keys and the newest version thereof (highest seq)
                     meta_type = record.key[len(prefix)]
@@ -525,13 +485,14 @@ class IndexedDb:
         os_meta = {}
 
         for db_id in self.global_metadata.db_ids:
-            # if db_id.dbid_no > 0x7f:
-            #     raise NotImplementedError("there could be this many dbs, but I don't support it yet")
-            #
+
+            if db_id.dbid_no is None:
+                continue
+
             # prefix = bytes([0, db_id.dbid_no, 0, 0, 50])
             prefix = IndexedDb.make_prefix(db_id.dbid_no, 0, 0, [50])
 
-            for record in self._db.iterate_records_raw(reverse=True):
+            for record in reversed(self._fetched_records):
                 if record.key.startswith(prefix) and record.state == ccl_leveldb.KeyState.Live:
                     # we only want live keys and the newest version thereof (highest seq)
                     objstore_id, varint_raw = _le_varint_from_bytes(record.key[len(prefix):])

--- a/ccl_chromium_indexeddb.py
+++ b/ccl_chromium_indexeddb.py
@@ -573,7 +573,7 @@ class IndexedDb:
         # goodness me this is a slow way of doing things
         prefix = IndexedDb.make_prefix(db_id, store_id, 1)
 
-        for record in self._fetched_records():
+        for record in self._fetched_records:
             if record.key.startswith(prefix):
                 key = IdbKey(record.key[len(prefix):])
                 if not record.value:
@@ -659,7 +659,7 @@ class IndexedDb:
 
         # This is a slow way of doing this:
         prefix = bytes.fromhex("00 00 00 00 32")
-        for record in self._fetched_records():
+        for record in self._fetched_records:
             if record.state != ccl_leveldb.KeyState.Live:
                 continue
             if record.user_key.startswith(prefix):


### PR DESCRIPTION
Hi Alex,

I have noticed that the metadata collection of the IndexedDB is still very slow as the database gets iterated up to 5 times.

In this PR I propose a quicker way of doing things, by caching the records of the raw database.

Furthermore, I have reduced some redundant code from the _fetch_meta_data function and instead calling the individual functions responsible for fetching the metadata for global, DB and the individual object stores.

Words of Caution:
* I did some basic testing with my databases and didn't run into any issues. However, you might want to also do some testing of your own.

* In my test data I had a database without a db ID, that's why I handled these cases separately. Maybe it would be better to ignore these databases all together, as they lead to various currently unhandled problems.

Let me know what you think.