### PR TITLE
Fix double-multiplied byte offset for block-spanning log/manifest records

### DIFF
--- a/ccl_chromium_reader/storage_formats/ccl_leveldb.py
+++ b/ccl_chromium_reader/storage_formats/ccl_leveldb.py
@@ -329,7 +329,7 @@ class LogFile:
                                              f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
                         block += buff.read(length)
                         in_record = False
-                        yield start_block_offset * LogFile.LOG_BLOCK_SIZE, block
+                        yield start_block_offset, block
                     else:
                         raise ValueError()  # Cannot happen
 
@@ -525,7 +525,7 @@ class ManifestFile:
                                              f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
                         block += buff.read(length)
                         in_record = False
-                        yield start_block_offset * LogFile.LOG_BLOCK_SIZE, block
+                        yield start_block_offset, block
                     else:
                         raise ValueError()  # Cannot happen
 


### PR DESCRIPTION
 ## Summary
  `LogFile._get_batches` and `ManifestFile._get_batches` report a record's byte
  offset two ways. For a non-fragmented (`Full`) record the offset is correct
  (`idx * LOG_BLOCK_SIZE + buff.tell()`). But for a record fragmented across a
  32 KiB log block, the `First`-fragment offset is computed correctly into
  `start_block_offset` and then **multiplied by `LOG_BLOCK_SIZE` again** when the
  reassembled record is yielded:

      yield start_block_offset * LogFile.LOG_BLOCK_SIZE, block

  So any block-spanning record gets an offset of `true_offset * 32768` — values in
  the billions for records that merely straddle a block boundary.

  ## Fix
  Yield `start_block_offset` directly (in both `LogFile` and `ManifestFile`).

  ## Repro / verification
  Observed in a Chrome `Extension State` log (~950 KB): records straddling the
  32768/65536/98304 boundaries reported offsets like 987,660,300 / 2,126,610,444 /
  3,129,376,780. After the fix every record's offset falls within its source file.

<img width="844" height="740" alt="image" src="https://github.com/user-attachments/assets/ac7a5410-33d8-40b3-9674-d6acc3cf983d" />
